### PR TITLE
npm settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ lib/*.js
 demo/dist/*.js
 node_modules/*
 gh-pages
+*.tgz

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Reader/Writer for png image's pHYs chunk on browsers.
 Detect width, height and DPI for PNG image.
 ```js
 const res = await fetch(srcUrl, {mode: 'cors'})
-arrayBuffer = await res.arrayBuffer()
+const arrayBuffer = await res.arrayBuffer()
 
 const {width, height, dpi} = parsePngFormat(arrayBuffer)
 ```

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -6,7 +6,7 @@ const loadImage = async srcUrl => {
   const arrayBuffer = await res.arrayBuffer()
   if (!arrayBuffer) return
   // 遠回しだが、convertToDataURIの動作確認を兼ねている
-  const base64DataURI = convertToDataURI(new Uint8Array(arrayBuffer))
+  const base64DataURI = convertToDataURI(arrayBuffer)
   const orgByteArray = convertToByteArray(base64DataURI)
   const dpr = window.devicePixelRatio
   const genByteArray = writePngDpi(orgByteArray, dpr * 72)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "png-chunk-phys",
-  "version": "3.1.5",
-  "description": "",
+  "version": "1.0.0",
+  "description": "Reader/Writer for png chunk pHYs on browsers",
   "main": "lib/index.js",
   "scripts": {
     "start": "./node_modules/.bin/http-server -c-1 -p 9006",
@@ -29,5 +29,6 @@
     "npm-run-all": "^4.1.5",
     "watchify": "^3.11.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "private": true
 }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,18 @@
 {
   "name": "png-chunk-phys",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Reader/Writer for png chunk pHYs on browsers",
   "main": "lib/index.js",
   "scripts": {
     "start": "./node_modules/.bin/http-server -c-1 -p 9006",
-    "watch-demo": "watchify demo/src/index.js -v -t babelify -o demo/dist/demo.js",
+    "watch:demo": "watchify demo/src/index.js -v -t babelify -o demo/dist/demo.js",
     "build": "run-s build:*",
+    "build:clean": "if test -d ./lib; then rm -r ./lib; fi",
     "build:babel": "./node_modules/.bin/babel src/ --out-dir lib/ --minified",
     "build:demo": "browserify demo/src/index.js -v -t babelify -o demo/dist/demo.js",
     "test": "mocha './test/*.js' --timeout 20000 --exit",
-    "gh-pages": "sh ./tools/gh-pages.sh"
+    "gh-pages": "sh ./tools/gh-pages.sh",
+    "npm-publish": "npm run build:babel && npm run test && npm publish"
   },
   "author": "Daiki Iizuka <iizuka@daiiz.org>",
   "license": "MIT",
@@ -30,7 +32,7 @@
     "watchify": "^3.11.0"
   },
   "dependencies": {},
-  "private": true,
+  "private": false,
   "files": [
     "lib",
     "package.json",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,10 @@
     "watchify": "^3.11.0"
   },
   "dependencies": {},
-  "private": true
+  "private": true,
+  "files": [
+    "lib",
+    "package.json",
+    "README.md"
+  ]
 }

--- a/src/share.js
+++ b/src/share.js
@@ -40,7 +40,8 @@ export function getCharCodes (str) {
 
 const dataURIScheme = 'data:image/png;base64,'
 
-export function convertToDataURI (byteArray) {
+export function convertToDataURI (arrayBuffer) {
+  const byteArray = new Uint8Array(arrayBuffer)
   return dataURIScheme + btoa(byteArray.reduce((data, byte) => {
     return data + String.fromCharCode(byte)
   }, ''))

--- a/src/writer.js
+++ b/src/writer.js
@@ -31,8 +31,9 @@ function insertChunkPhys (byteArray, ptr, dpi=72) {
   return newByteArray
 }
 
-export function writePngDpi (byteArray, dpi=72) {
+export function writePngDpi (arrayBuffer, dpi=72) {
   const ptr = {pos: 0}
+  const byteArray = new Uint8Array(arrayBuffer)
   if (!isPng(byteArray, ptr)) return byteArray
   readIHDR(byteArray, ptr)
 

--- a/tools/gh-pages.sh
+++ b/tools/gh-pages.sh
@@ -7,6 +7,7 @@ cp README.md gh-pages/README.md
 cp package.json gh-pages/package.json
 cp -r demo gh-pages/demo
 cp -r lib gh-pages/lib
+cp -r .circleci gh-pages/.circleci
 
 rm -r ./gh-pages/demo/src
 


### PR DESCRIPTION
- package.jsonのfilesフィールドに書いたファイル (ディレクトリ) だけnpmとして公開できる
  - .npmignoreを書いてもよいが、packするファイルよりもignoreの方が多いときは大変
- `$ npm pack` を実行すると、公開されるファイル一覧を確認できる
   - tgzが生成される
   - `$ npm install ./foo.tgz` のように使うこともできる。低速回線環境で便利。